### PR TITLE
Prices compared as strings instead of ints.

### DIFF
--- a/src/pages/CreateListing.jsx
+++ b/src/pages/CreateListing.jsx
@@ -75,7 +75,7 @@ function CreateListing() {
 
     setLoading(true)
 
-    if (discountedPrice >= regularPrice) {
+    if (parseInt(discountedPrice) >= parseInt(regularPrice) {
       setLoading(false)
       toast.error('Discounted price needs to be less than regular price')
       return


### PR DESCRIPTION
## Issue
By default, event.target.value is a string. This causes issues when comparing the two. 
## Steps to reproduce:
![Screen Shot 2022-03-07 at 3 19 07 PM (2)](https://user-images.githubusercontent.com/12053461/157119854-ecfc27e1-cc86-41d0-8db6-8de5e4b89d77.png)
The string `10000` is less than `5000` in alphabetical order. Since we have a generic setter under `onMutate`, we can parse the prices as ints when comparing to resolve the issue.