### PR TITLE
use docRef instead of call table again

### DIFF
--- a/src/components/OAuth.jsx
+++ b/src/components/OAuth.jsx
@@ -22,7 +22,7 @@ function OAuth() {
 
       // If user, doesn't exist, create user
       if (!docSnap.exists()) {
-        await setDoc(doc(docRef), {
+        await setDoc(docRef), {
           name: user.displayName,
           email: user.email,
           timestamp: serverTimestamp(),

--- a/src/components/OAuth.jsx
+++ b/src/components/OAuth.jsx
@@ -22,7 +22,7 @@ function OAuth() {
 
       // If user, doesn't exist, create user
       if (!docSnap.exists()) {
-        await setDoc(doc(db, 'users', user.uid), {
+        await setDoc(doc(docRef), {
           name: user.displayName,
           email: user.email,
           timestamp: serverTimestamp(),


### PR DESCRIPTION
I found that we had already created the variable doRef to get the user from the table, so I used it again down instead of calling the table again.