### PR TITLE
Minor css issue on contact page when screen height is less than 730px

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -118,6 +118,10 @@ button {
   align-items: center;
 }
 
+.pageContainer{
+  margin-bottom: 10rem;
+}
+
 .loadingSpinner {
   width: 64px;
   height: 64px;


### PR DESCRIPTION
1 - Send message button on Contact Landlord page does not appear when the screen height is less than 730 px, because it is hidden on the navbar that is on the bottom.

Fix: Apply margin-bottom : 10rem; on .pageContainer class on index.css