### PR TITLE
FIX: css typo listingsList

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -118,7 +118,7 @@ button {
   align-items: center;
 }
 
-.pageContainer{
+.pageContainer {
   margin-bottom: 10rem;
 }
 
@@ -711,7 +711,7 @@ button {
   font-weight: 600;
 }
 
-.lisitingsList {
+.listingsList {
   padding: 0;
 }
 


### PR DESCRIPTION
In `profile` page's code `ul` has the class called `listingsList`   

```javascript
<ul className='listingsList'>
 ...
</ul>
```

but in css file the corresponding class name was called `lisitingsList`. I fixed the typo. 

```css
.listingsList {
  padding: 0;
}
```

The effect of typo like below screenshots;

<br>

BEFORE

![image](https://drive.google.com/uc?export=view&id=1ZfXy5EvNMRi_KH19XmUxzJZLcXRW70jL)

<br>

AFTER

![image](https://drive.google.com/uc?export=view&id=1_Qb0daPNqQb9rGLefGir10Z81_wNPC1q)

Also small fix: add space after `pageContainer`  